### PR TITLE
Use IRAM_ATTR in place of ICACHE_RAM_ATTR

### DIFF
--- a/esphome-opentherm/opentherm_component.h
+++ b/esphome-opentherm/opentherm_component.h
@@ -11,7 +11,7 @@ int inPin = D2;
 int outPin = D1;
 OpenTherm ot(inPin, outPin, false);
 
-ICACHE_RAM_ATTR void handleInterrupt() {
+IRAM_ATTR void handleInterrupt() {
 	ot.handleInterrupt();
 }
 

--- a/opentherm.yaml
+++ b/opentherm.yaml
@@ -7,8 +7,8 @@ esphome:
   platform: ESP8266
   board: d1_mini
   platformio_options:
-    lib_deps: 
-    - ihormelnyk/OpenTherm Library @ 1.1.3
+    lib_deps:
+    - ihormelnyk/OpenTherm Library @ 1.1.4
   includes:
     - esphome-opentherm/
 


### PR DESCRIPTION
Arduino framework for esp8266 introduced this change with version 3 (to use the same IRAM_ATTR as in ESP32)

Bump OpenTherm Library from version 1.1.3 to 1.1.4 due to the same changes (https://github.com/ihormelnyk/opentherm_library/pull/46)